### PR TITLE
cancel replication of pouchdb on disconnect

### DIFF
--- a/client.js
+++ b/client.js
@@ -133,6 +133,10 @@ function createClient(createStream) {
         debug('syncing %j to remote %j', spec.db._db_name, remoteDB._db_name);
         dbSync = spec.dbSync = PouchDB.sync(spec.db, remoteDB, {live: true});
 
+        r.once('disconnect', function onEvent() {
+          dbSync.cancel();
+        });
+
         interestingSyncEvents.forEach(function eachEvent(event) {
           dbSync.on(event, function onEvent(payload) {
             spec.ret.emit(event, payload);


### PR DESCRIPTION
Hi,

I use this library through https://github.com/pgte/pouch-websocket-sync.
If a disconnect occurs the replication of the PouchDB is not canceled but another sync() is created on reconnect/connect. This causes another changes feed which results in the following error for me.

**(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.**

The following seems to fix the problem.
