### PR TITLE
Fix bug with pouch-remote-stream

### DIFF
--- a/client.js
+++ b/client.js
@@ -127,6 +127,7 @@ function createClient(createStream) {
         var remote = PouchRemoteStream();
         var remoteDB = new PouchDB({
           name: spec.options.remoteName,
+          originalName: spec.options.remoteName,
           adapter: 'remote',
           remote: remote,
         });


### PR DESCRIPTION
The pouch-remote-stream adapter needs [originalName for a correct execution](https://github.com/pgte/pouch-remote-stream/blob/master/adapter.js#L53). This is the source this issues:

- [in pouch-stream-server](https://github.com/pgte/pouch-stream-server/issues/2)
- [in pouch-websocket-sync](https://github.com/pgte/pouch-websocket-sync/issues/7)